### PR TITLE
Add sbtopts file with jvm option needed to start the admin

### DIFF
--- a/admin/.sbtopts
+++ b/admin/.sbtopts
@@ -1,0 +1,1 @@
+-Dorg.quartz.properties=./conf/quartz.properties


### PR DESCRIPTION
I wanted to be able to start the Piezo admin using straight sbt without tmux. This should accomplish this, but I do not know if this is the best way to do this. Maybe there is a way to add this jvm option to Build.scala? Just let me know.
