### PR TITLE
update admin run script to use play's generated bash script

### DIFF
--- a/admin/bin/run.sh
+++ b/admin/bin/run.sh
@@ -1,7 +1,10 @@
 #!/bin/bash
 
-SOURCE_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-DEPS_DIR="$SOURCE_DIR/../target/staged"
-QUARTZ_PROPS_FILE="$SOURCE_DIR/../conf/quartz.properties"
+echo "Run 'make stage' before running this script."
 
-java -Dorg.quartz.properties=$QUARTZ_PROPS_FILE -Dpidfile.path=/tmp/pid -Dnetworkaddress.cache.ttl=10 -Dnetworkaddress.cache.negative.ttl=10 -Dhttp.port=8001 -cp "${DEPS_DIR}/*" play.core.server.NettyServer
+SOURCE_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+BASE_DIR="$SOURCE_DIR/.."
+QUARTZ_PROPS_FILE="$BASE_DIR/conf/quartz.properties"
+START="$BASE_DIR/target/universal/stage/bin/admin"
+
+$START -Dorg.quartz.properties=$QUARTZ_PROPS_FILE -Dpidfile.path=/tmp/pid -Dnetworkaddress.cache.ttl=10 -Dnetworkaddress.cache.negative.ttl=10 -Dhttp.port=8001


### PR DESCRIPTION
Play generates a bash script under target/universal (see https://www.playframework.com/documentation/2.4.x/Production). We should just use that to run the admin.

@timsama do you mind reviewing this?