### PR TITLE
Add a missing index and a maximum amount of time between trigger successes

### DIFF
--- a/admin/app/com/lucidchart/piezo/admin/views/editTrigger.scala.html
+++ b/admin/app/com/lucidchart/piezo/admin/views/editTrigger.scala.html
@@ -1,7 +1,6 @@
 @(
 triggersByGroup: scala.collection.mutable.Buffer[(String, scala.collection.immutable.List[org.quartz.TriggerKey])],
-triggerForm: Form[(org.quartz.Trigger, com.lucidchart.piezo.TriggerMonitoringPriority.Value)],
-triggerMonitoringPriority: com.lucidchart.piezo.TriggerMonitoringPriority.TriggerMonitoringPriority = com.lucidchart.piezo.TriggerMonitoringPriority.Off,
+triggerForm: Form[(org.quartz.Trigger, com.lucidchart.piezo.TriggerMonitoringPriority.Value, Int)],
 formAction: play.api.mvc.Call,
 existing: Boolean,
 isTemplate: Boolean,
@@ -66,7 +65,10 @@ request: play.api.mvc.Request[AnyContent]
       <input type="text" class="job-name-type-ahead form-control form-inline-control " name="@name" id="@id" @toHtmlArgs(args)>
     }
     }
-    @helper.select(triggerForm("triggerMonitoringPriority"), TriggerMonitoringPriority.values.toList.map(tp => tp.toString -> tp.toString), '_label -> "Monitoring Priority", 'labelClass -> "col-sm-2 text-right", 'inputDivClass -> "col-sm-4", 'class -> "form-control", 'placeholder -> TriggerMonitoringPriority.Off)
+    @helper.select(triggerForm("triggerMonitoringPriority"), TriggerMonitoringPriority.values.toList.map(tp => tp.toString -> tp.toString), '_label -> "Monitoring Priority", 'labelClass -> "col-sm-2 text-right", 'inputDivClass -> "col-sm-4", 'class -> "form-control", 'value -> triggerForm.data.get("triggerMonitoringPriority").getOrElse(TriggerMonitoringPriority.Off), 'placeholder -> TriggerMonitoringPriority.Off)
+    @helper.input(triggerForm("triggerMaxErrorTime"), '_label -> "Monitoring - Max Seconds Between Successes", 'labelClass -> "col-sm-2 text-right", 'inputDivClass -> "col-sm-4", 'placeholder -> "", 'value -> triggerForm.data.get("triggerMaxErrorTime").getOrElse(300)) { (id, name, value, args) =>
+      <input type="number" class="form-control form-inline-control " name="@name" id="@id" @toHtmlArgs(args)>
+    }
 
     @helper.input(triggerForm("description"), '_label -> "Description", 'labelClass -> "col-sm-2 text-right", 'inputDivClass -> "col-sm-10", 'placeholder -> "Description", 'value-> triggerForm.data.get("description").getOrElse("")) { (id, name, value, args) =>
       <input type="text" class="form-control form-inline-control " name="@name" id="@id" @toHtmlArgs(args)>

--- a/admin/app/com/lucidchart/piezo/admin/views/trigger.scala.html
+++ b/admin/app/com/lucidchart/piezo/admin/views/trigger.scala.html
@@ -3,7 +3,8 @@ triggersByGroup: scala.collection.mutable.Buffer[(String, scala.collection.immut
 currentTrigger: Option[org.quartz.Trigger],
 triggerHistory: Option[List[com.lucidchart.piezo.TriggerRecord]],
 errorMessage: Option[String] = None,
-triggerMonitoringPriority: Option[com.lucidchart.piezo.TriggerMonitoringPriority.Value] = None
+triggerMonitoringPriority: Option[com.lucidchart.piezo.TriggerMonitoringPriority.Value] = None,
+triggerMaxErrorTime: Integer = 300
 )(
 implicit
 request: play.api.mvc.Request[AnyContent]
@@ -123,6 +124,10 @@ request: play.api.mvc.Request[AnyContent]
             <tr>
                 <td class="text-right">Monitoring priority:</td>
                 <td>@triggerMonitoringPriority</td>
+            </tr>
+            <tr>
+                <td class="text-right">Monitoring - max seconds between successes:</td>
+                <td>@triggerMaxErrorTime seconds</td>
             </tr>
             }
             <tr>

--- a/admin/project/Build.scala
+++ b/admin/project/Build.scala
@@ -12,7 +12,7 @@ object ApplicationBuild extends Build {
     jdbc,
     anorm,
     "org.quartz-scheduler" % "quartz" % "2.1.7",
-    "com.lucidchart" %% "piezo-worker" % "1.15"
+    "com.lucidchart" %% "piezo-worker" % "1.16"
   )
 
   val main = Project(appName, file(".")).enablePlugins(play.PlayScala).settings(

--- a/worker/build.sbt
+++ b/worker/build.sbt
@@ -2,7 +2,7 @@ name := "piezo-worker"
 
 organization := "com.lucidchart"
 
-version := "1.16-SNAPSHOT"
+version := "1.16"
 
 scalaVersion := "2.11.7"
 

--- a/worker/src/main/resources/piezo_mysql_3.sql
+++ b/worker/src/main/resources/piezo_mysql_3.sql
@@ -1,12 +1,8 @@
-
-ALTER TABLE `job_history`
-  MODIFY COLUMN trigger_name VARCHAR(100) NOT NULL,
-  MODIFY COLUMN trigger_group VARCHAR(100) NOT NULL,
-  MODIFY COLUMN job_name VARCHAR(100) NOT NULL,
-  MODIFY COLUMN job_group VARCHAR(100) NOT NULL,
-  DROP KEY job_key,
-  ADD KEY job_key (job_group, job_name, start);
-
-ALTER TABLE `trigger_history`
-  MODIFY COLUMN trigger_name VARCHAR(100) NOT NULL,
-  MODIFY COLUMN trigger_group VARCHAR(100) NOT NULL;
+CREATE TABLE trigger_monitoring_priority(
+    trigger_name VARCHAR(190) NOT NULL,
+    trigger_group VARCHAR(190) NOT NULL,
+    priority TINYINT DEFAULT NULL,
+    created datetime NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    modified datetime NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    PRIMARY KEY(trigger_group, trigger_name)
+);

--- a/worker/src/main/resources/piezo_mysql_4.sql
+++ b/worker/src/main/resources/piezo_mysql_4.sql
@@ -1,8 +1,2 @@
-CREATE TABLE trigger_monitoring_priority(
-    trigger_name VARCHAR(190) NOT NULL,
-    trigger_group VARCHAR(190) NOT NULL,
-    priority TINYINT DEFAULT NULL,
-    created datetime NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    modified datetime NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
-    PRIMARY KEY(trigger_group, trigger_name)
-);
+INSERT INTO trigger_monitoring_priority (trigger_name, trigger_group, priority)
+SELECT TRIGGER_NAME, TRIGGER_GROUP, 3 from QRTZ_TRIGGERS;

--- a/worker/src/main/resources/piezo_mysql_5.sql
+++ b/worker/src/main/resources/piezo_mysql_5.sql
@@ -1,3 +1,1 @@
-INSERT INTO trigger_monitoring_priority (trigger_name, trigger_group, priority) 
-SELECT TRIGGER_NAME, TRIGGER_GROUP, 3 from QRTZ_TRIGGERS;
-
+ALTER TABLE trigger_monitoring_priority ADD max_error_time MEDIUMINT NOT NULL;

--- a/worker/src/main/resources/piezo_mysql_6.sql
+++ b/worker/src/main/resources/piezo_mysql_6.sql
@@ -1,0 +1,1 @@
+ALTER TABLE job_history ADD INDEX trigger_success_key (trigger_group, trigger_name, success, start);

--- a/worker/src/main/resources/piezo_mysql_7.sql
+++ b/worker/src/main/resources/piezo_mysql_7.sql
@@ -1,0 +1,1 @@
+UPDATE trigger_monitoring_priority set max_error_time = 300;

--- a/worker/src/main/scala/com/lucidchart/piezo/WorkerJobListener.scala
+++ b/worker/src/main/scala/com/lucidchart/piezo/WorkerJobListener.scala
@@ -10,7 +10,7 @@ object WorkerJobListener {
 
 class WorkerJobListener(props: Properties) extends JobListener {
   val jobHistoryModel = new JobHistoryModel(props)
-  val triggerMonitoringPriorityModel = new TriggerMonitoringPriorityModel(props)
+  val triggerMonitoringPriorityModel = new TriggerMonitoringModel(props)
   def getName: String = "WorkerJobListener"
 
   def jobToBeExecuted(context: JobExecutionContext) {}
@@ -26,8 +26,8 @@ class WorkerJobListener(props: Properties) extends JobListener {
       val statsKey = "jobs." + context.getTrigger.getJobKey.getGroup + "." + context.getTrigger.getJobKey.getName + suffix
 
       if (props.getProperty("com.lucidchart.piezo.enableMonitoring") == "new") {
-        triggerMonitoringPriorityModel.getTriggerMonitoringPriority(context.getTrigger).map { triggerMonitoringPriority =>
-          if (triggerMonitoringPriority > TriggerMonitoringPriority.Off) {
+        triggerMonitoringPriorityModel.getTriggerMonitoringRecord(context.getTrigger).map { triggerMonitoringRecord =>
+          if (triggerMonitoringRecord.priority > TriggerMonitoringPriority.Off) {
             StatsD.increment(statsKey)
           }
         }

--- a/worker/src/main/scala/com/lucidchart/piezo/WorkerTriggerListener.scala
+++ b/worker/src/main/scala/com/lucidchart/piezo/WorkerTriggerListener.scala
@@ -11,7 +11,7 @@ object WorkerTriggerListener {
 
 class WorkerTriggerListener(props: Properties) extends TriggerListener {
   val triggerHistoryModel = new TriggerHistoryModel(props)
-  val triggerMonitoringPriorityModel = new TriggerMonitoringPriorityModel(props)
+  val triggerMonitoringPriorityModel = new TriggerMonitoringModel(props)
   def getName:String = "WorkerTriggerListener"
 
   def vetoJobExecution(trigger: Trigger, context: JobExecutionContext):Boolean = false
@@ -24,8 +24,8 @@ class WorkerTriggerListener(props: Properties) extends TriggerListener {
       val statsKey = "triggers." + trigger.getKey.getGroup + "." + trigger.getKey.getName + ".completed"
 
       if (props.getProperty("com.lucidchart.piezo.enableMonitoring") == "new") {
-        triggerMonitoringPriorityModel.getTriggerMonitoringPriority(trigger).map { triggerMonitoringPriority =>
-          if (triggerMonitoringPriority > TriggerMonitoringPriority.Off) {
+        triggerMonitoringPriorityModel.getTriggerMonitoringRecord(trigger).map { triggerMonitoringRecord =>
+          if (triggerMonitoringRecord.priority > TriggerMonitoringPriority.Off) {
             StatsD.increment(statsKey)
           }
         }
@@ -39,10 +39,10 @@ class WorkerTriggerListener(props: Properties) extends TriggerListener {
 
   def triggerMisfired(trigger: Trigger) {
     try {
-      triggerMonitoringPriorityModel.getTriggerMonitoringPriority(trigger).map { triggerMonitoringPriority =>
+      triggerMonitoringPriorityModel.getTriggerMonitoringRecord(trigger).map { triggerMonitoringRecord =>
         triggerHistoryModel.addTrigger(trigger,None,misfire = true,None)
 
-        if (triggerMonitoringPriority > TriggerMonitoringPriority.Off) {
+        if (triggerMonitoringRecord.priority > TriggerMonitoringPriority.Off) {
           val statsKey = "triggers." + trigger.getKey.getGroup + "." + trigger.getKey.getName + ".misfired"
           StatsD.increment(statsKey)
         }


### PR DESCRIPTION
Two changes:

Add an index to the job_history table to be able to query it by trigger
    
Currently the job_history table has indices to query by job name and group.
The table also stores trigger information, but has no index to query it.
This adds an index to be able to query by trigger name and group, so the
ability to query job history by trigger added in 1.15 is not incredibly
slow. 

Add a maximum amount of time between successes for each trigger.

This is a continuation of the monitoring work done by adding monitoring
priority. This adds an SLA for each trigger - the maximum number of time
that can pass between successes. We have a Job at Lucidchart which enforces
this internally. Including it in the Piezo project requires us to open
source an additional project. Until then, you can write a job that consumes
this information and alerts when a trigger is in an error state.