### PR TITLE
Use current time instead of 1970 when recording triggers without a start_time

### DIFF
--- a/admin/project/Build.scala
+++ b/admin/project/Build.scala
@@ -19,7 +19,7 @@ object ApplicationBuild extends Build {
     retrieveManaged := true,
     version := appVersion,
     libraryDependencies ++= appDependencies,
-    scalaVersion := "2.11.7",
+    scalaVersion := "2.11.8",
     resolvers ++= List(
       Resolver.file("local ivy repository", file(System.getenv("HOME") + "/.ivy2/local/"))(Resolver.ivyStylePatterns),
       "Sonatype OSS Snapshots" at "https://oss.sonatype.org/content/repositories/snapshots",

--- a/worker/build.sbt
+++ b/worker/build.sbt
@@ -4,9 +4,9 @@ organization := "com.lucidchart"
 
 version := "1.18-SNAPSHOT"
 
-scalaVersion := "2.11.7"
+scalaVersion := "2.11.8"
 
-crossScalaVersions := Seq(scalaVersion.value, "2.11.6")
+crossScalaVersions := Seq(scalaVersion.value, "2.11.7")
 
 exportJars := true
 

--- a/worker/src/main/scala/com/lucidchart/piezo/TriggerHistoryModel.scala
+++ b/worker/src/main/scala/com/lucidchart/piezo/TriggerHistoryModel.scala
@@ -23,7 +23,19 @@ class TriggerHistoryModel(props: Properties) {
   def addTrigger(trigger: Trigger, actualStart: Option[Date], misfire: Boolean, fireInstanceId: Option[String]) {
     val connection = connectionProvider.getConnection
     try {
-      val prepared = connection.prepareStatement("""INSERT INTO trigger_history(trigger_name, trigger_group, scheduled_start, actual_start, finish, misfire, fire_instance_id) VALUES(?, ?, ?, ?, ?, ?, ?)""")
+      val prepared = connection.prepareStatement(
+        """
+          INSERT INTO trigger_history(
+            trigger_name,
+            trigger_group,
+            scheduled_start,
+            actual_start,
+            finish,
+            misfire,
+            fire_instance_id
+          ) VALUES(?, ?, ?, ?, ?, ?, ?)
+        """.stripMargin
+      )
       prepared.setString(1, trigger.getKey.getName)
       prepared.setString(2, trigger.getKey.getGroup)
       prepared.setTimestamp(3, new Timestamp(Option(trigger.getPreviousFireTime).getOrElse(new Date).getTime))

--- a/worker/src/main/scala/com/lucidchart/piezo/TriggerHistoryModel.scala
+++ b/worker/src/main/scala/com/lucidchart/piezo/TriggerHistoryModel.scala
@@ -26,7 +26,7 @@ class TriggerHistoryModel(props: Properties) {
       val prepared = connection.prepareStatement("""INSERT INTO trigger_history(trigger_name, trigger_group, scheduled_start, actual_start, finish, misfire, fire_instance_id) VALUES(?, ?, ?, ?, ?, ?, ?)""")
       prepared.setString(1, trigger.getKey.getName)
       prepared.setString(2, trigger.getKey.getGroup)
-      prepared.setTimestamp(3, new Timestamp(Option(trigger.getPreviousFireTime).getOrElse(new Date(0)).getTime))
+      prepared.setTimestamp(3, new Timestamp(Option(trigger.getPreviousFireTime).getOrElse(new Date).getTime))
       prepared.setTimestamp(4, actualStart.map(date => new Timestamp(date.getTime)).getOrElse(null))
       prepared.setTimestamp(5, new Timestamp(System.currentTimeMillis))
       prepared.setBoolean(6, misfire)

--- a/worker/src/main/scala/com/lucidchart/piezo/WorkerTriggerListener.scala
+++ b/worker/src/main/scala/com/lucidchart/piezo/WorkerTriggerListener.scala
@@ -12,15 +12,19 @@ object WorkerTriggerListener {
 class WorkerTriggerListener(props: Properties) extends TriggerListener {
   val triggerHistoryModel = new TriggerHistoryModel(props)
   val triggerMonitoringPriorityModel = new TriggerMonitoringModel(props)
-  def getName:String = "WorkerTriggerListener"
+  def getName: String = "WorkerTriggerListener"
 
-  def vetoJobExecution(trigger: Trigger, context: JobExecutionContext):Boolean = false
+  def vetoJobExecution(trigger: Trigger, context: JobExecutionContext): Boolean = false
 
-  def triggerFired(trigger: Trigger, context: JobExecutionContext) {}
+  def triggerFired(trigger: Trigger, context: JobExecutionContext):  Unit = {}
 
-  def triggerComplete(trigger: Trigger, context: JobExecutionContext, triggerInstructionCode: CompletedExecutionInstruction) {
+  def triggerComplete(
+    trigger: Trigger,
+    context: JobExecutionContext,
+    triggerInstructionCode: CompletedExecutionInstruction
+  ): Unit = {
     try {
-      triggerHistoryModel.addTrigger(trigger, Some(context.getFireTime), misfire=false, Some(context.getFireInstanceId))
+      triggerHistoryModel.addTrigger(trigger, Some(context.getFireTime), misfire = false, Some(context.getFireInstanceId))
       val statsKey = "triggers." + trigger.getKey.getGroup + "." + trigger.getKey.getName + ".completed"
 
       if (props.getProperty("com.lucidchart.piezo.enableMonitoring") == "new") {
@@ -37,10 +41,10 @@ class WorkerTriggerListener(props: Properties) extends TriggerListener {
     }
   }
 
-  def triggerMisfired(trigger: Trigger) {
+  def triggerMisfired(trigger: Trigger): Unit = {
     try {
       triggerMonitoringPriorityModel.getTriggerMonitoringRecord(trigger).map { triggerMonitoringRecord =>
-        triggerHistoryModel.addTrigger(trigger,None,misfire = true,None)
+        triggerHistoryModel.addTrigger(trigger, None, misfire = true, None)
 
         if (triggerMonitoringRecord.priority > TriggerMonitoringPriority.Off) {
           val statsKey = "triggers." + trigger.getKey.getGroup + "." + trigger.getKey.getName + ".misfired"


### PR DESCRIPTION
When a trigger misfires, we add that trigger to the trigger history. However, we do not have the fire_instance_id and start_time when the trigger misfires. Those values are part of the primary key. Accordingly, when we logged misfires multiple times, we encounter duplicate primary key errors.
