### PR TITLE
Improve error handling when updating the trigger histories

### DIFF
--- a/worker/src/main/scala/com/lucidchart/piezo/TriggerHistoryModel.scala
+++ b/worker/src/main/scala/com/lucidchart/piezo/TriggerHistoryModel.scala
@@ -34,6 +34,14 @@ class TriggerHistoryModel(props: Properties) {
             misfire,
             fire_instance_id
           ) VALUES(?, ?, ?, ?, ?, ?, ?)
+          ON DUPLICATE KEY UPDATE
+            trigger_name = Values(trigger_name),
+            trigger_group = Values(trigger_group),
+            scheduled_start = Values(scheduled_start),
+            actual_start = Values(actual_start),
+            finish = Values(finish),
+            misfire = Values(misfire),
+            fire_instance_id = Values(fire_instance_id)
         """.stripMargin
       )
       prepared.setString(1, trigger.getKey.getName)


### PR DESCRIPTION
If a trigger misfires, insert it into the trigger histories and update on duplicate keys.

In the case of a mis fired trigger, inserting into the DB shouldn't cause an exception. Instead, we should update the existing entry to match the misfired trigger matching the primary key. This can happen many times until the trigger stops misfiring.