### PR TITLE
Use .next() instead of .first() to move to first row.

### DIFF
--- a/worker/src/main/scala/com/lucidchart/piezo/TriggerMonitoringModel.scala
+++ b/worker/src/main/scala/com/lucidchart/piezo/TriggerMonitoringModel.scala
@@ -104,7 +104,7 @@ class TriggerMonitoringModel(props: Properties) {
       prepared.setString(1, trigger.getKey.getName)
       prepared.setString(2, trigger.getKey.getGroup)
       val rs = prepared.executeQuery()
-      if (rs.first()) {
+      if (rs.next()) {
         TriggerMonitoringPriority.values.find(_.id == rs.getInt("priority")).map { priority =>
           TriggerMonitoringRecord(
             rs.getString("trigger_name"),


### PR DESCRIPTION
.next() works if the ResultSet is TYPE_FORWARD_ONLY, but .first() isn't supposed to (but sometimes it does), because it might move backwards.

after running a query the cursor is before the first row, so if there is a returned record, .next() will move to that record.