### PR TITLE
Change Piezo UI to Prevent Job Trigger Periods that are Longer than the Monitoring Period

### DIFF
--- a/admin/app/com/lucidchart/piezo/admin/utils/CronHelper.scala
+++ b/admin/app/com/lucidchart/piezo/admin/utils/CronHelper.scala
@@ -1,0 +1,185 @@
+package com.lucidchart.piezo.admin.utils
+
+import java.util.{Date, TimeZone}
+import org.quartz.{CronExpression, CronScheduleBuilder, CronTrigger, TriggerBuilder}
+import play.api.Logging
+import scala.util.control.NonFatal
+
+object CronHelper extends Logging {
+  val DEFAULT_MAX_INTERVAL = 0
+  val NUM_COMPLEX_SAMPLES = 8000
+
+  /**
+   * Determines the max interval for a cron expression. The operation fails silently because it's not crucial.
+   * @param cronExpression
+   */
+  def getMaxInterval(cronExpression: CronExpression): Long = getMaxInterval(cronExpression, None)
+  def getMaxInterval(cronExpression: CronExpression, timeZone: Option[TimeZone]): Long = {
+    try {
+      val subexpressions = cronExpression.getCronExpression.split("\\s")
+      val isComplex = !subexpressions.drop(3).forall(expr => expr == "*" || expr == "?")
+      if (isComplex) getComplexMaxInterval(subexpressions, timeZone) else getSimpleMaxInterval(subexpressions, timeZone)
+    } catch {
+      case NonFatal(e) =>
+        logger.error("Failed to validate cron expression", e)
+        DEFAULT_MAX_INTERVAL
+    }
+  }
+
+  /**
+   * Determines the max interval by deduction. Is only used when seconds, minutes, and hours are specified. If days,
+   * months, or years are specified, use getComplexMaxInterval instead.
+   */
+  private def getSimpleMaxInterval(subexpressions: Array[String], timeZone: Option[TimeZone]): Long = {
+    val cronContainers = getCronContainers(subexpressions.take(3), timeZone) // seconds, minutes, hours
+    val outermostContainer = cronContainers.findLast(!_.areAllUnitsMarked)
+    outermostContainer.fold(1L) { outermost =>
+      val innerContainers = cronContainers.takeWhile(_.unitType != outermost.unitType)
+      val innerIntervalSeconds = innerContainers.map(_.wrapIntervalInSeconds).sum
+      outermost.maxIntervalInSeconds + innerIntervalSeconds
+    }
+  }
+
+  /**
+   * Estimates the max interval using a combination of deduction (for the seconds and minutes), and sampling (for
+   * everything else). We remove the seconds and minutes from the cron expression that is used for sampling so we can
+   * effectively decrease the number of samples needed for a good estimate.
+   */
+  private def getComplexMaxInterval(subexpressions: Array[String], timeZone: Option[TimeZone]): Long = {
+    val (secondsAndMinutes, everythingElse) = subexpressions.splitAt(2)
+
+    // set up the dummy trigger
+    val simplifiedComplexCron = everythingElse.mkString(s"0 0 ", " ", "")
+    val selectedTimeZone = timeZone.getOrElse(TimeZone.getDefault)
+    val cronSchedule = CronScheduleBuilder.cronSchedule(simplifiedComplexCron).inTimeZone(selectedTimeZone)
+    val dummyTrigger: CronTrigger = TriggerBuilder.newTrigger().withSchedule(cronSchedule).build()
+    val initialFireTime = Option(dummyTrigger.getFireTimeAfter(new Date()))
+
+    // get the interval
+    initialFireTime.fold(Long.MaxValue) { initialFireTime =>
+      logger.debug(s"sample cron expression: $simplifiedComplexCron")
+      val sampledMaxIntervalInSeconds = getSampledMaxInterval(initialFireTime, NUM_COMPLEX_SAMPLES, dummyTrigger)
+      val innerMaxIntervalSeconds = getCronContainers(secondsAndMinutes, timeZone).map(_.wrapIntervalInSeconds).sum
+      // subtract an hour to avoid double counting innerMaxIntervalSeconds
+      sampledMaxIntervalInSeconds - HourUnitType.secondsPerUnit + innerMaxIntervalSeconds
+    }
+  }
+
+  /**
+   * Estimates the max interval for a given cron expression. The more samples, the better the estimate.
+   */
+  private def getSampledMaxInterval(prev: Date, numSamples: Long, trigger: CronTrigger, maxInterval: Long = 0): Long = {
+    Option(trigger.getFireTimeAfter(prev)) match {
+      case Some(next) if numSamples > 0 =>
+        val intervalInSeconds = next.toInstant.getEpochSecond - prev.toInstant.getEpochSecond
+        if (intervalInSeconds > maxInterval) {
+          val sampleId = NUM_COMPLEX_SAMPLES - numSamples
+          logger.debug(s"Seconds:$intervalInSeconds Sample:$sampleId Interval:$prev -> $next")
+        }
+        getSampledMaxInterval(next, numSamples - 1, trigger, Math.max(intervalInSeconds, maxInterval))
+      case _ => maxInterval
+    }
+  }
+
+  private def getCronContainers(parts: Array[String], timeZone: Option[TimeZone]): List[CronContainer] = {
+    parts
+      .zip(List(SecondUnitType, MinuteUnitType, HourUnitType))
+      .map { case (str, cronType) => CronContainer(str, cronType, timeZone) }
+      .toList
+  }
+
+}
+
+sealed abstract class UnitType(val secondsPerUnit: Long, val numUnitsInContainer: Long)
+case object SecondUnitType extends UnitType(1, 60)
+case object MinuteUnitType extends UnitType(60, 60)
+case object HourUnitType extends UnitType(3600, 24)
+
+/**
+ * A cron container is composed of "units". The "unitType" determines how many units are in the container, and how many
+ * seconds are in each unit. "Marked units" describe when the trigger is set to fire. "Intervals" describe the number of
+ * units between (but not including) marked units.
+ */
+case class CronContainer(str: String, unitType: UnitType, markedUnits: List[Long], timeZone: TimeZone) {
+  lazy val areAllUnitsMarked: Boolean = markedUnits.size == unitType.numUnitsInContainer
+
+  // the "wrap interval" is the interval that wraps around both ends of the container
+  private lazy val wrapInterval = (unitType.numUnitsInContainer - markedUnits.last) + markedUnits.head
+  lazy val wrapIntervalInSeconds: Long = unitsToSeconds(wrapInterval)
+
+  // the max interval is the longest interval between any two marked units in the container, including the wrap interval
+  lazy val maxIntervalInSeconds: Long = {
+    val otherIntervals = markedUnits.zipWithIndex
+      .take(markedUnits.size - 1)
+      .map { case (value, index) => markedUnits(index + 1) - value }
+    val units = (otherIntervals :+ wrapInterval).max
+    val unitsWithDaylightSavings = units + (if (unitType == HourUnitType) getDaylightSavings(units, markedUnits) else 0)
+    unitsToSeconds(unitsWithDaylightSavings)
+  }
+
+  /**
+   * We multiply the number of units by the number of seconds in a single unit. We also subtract 1 unit to avoid double
+   * counting the seconds in sub-intervals that are within a single unit. For example:
+   *   - We subtract 1 hour when counting hours because the minutes make up the last hour
+   *   - We subtract 1 minute when counting minutes because the seconds make up the last minute
+   *   - We don't subtract 1 second when counting seconds because there are no smaller units
+   */
+  private def unitsToSeconds(units: Long): Long = {
+    if (unitType == SecondUnitType) units else (units - 1) * unitType.secondsPerUnit
+  }
+
+  /**
+   * Returns the number of seconds to add to the interval if daylight savings is being observed.
+   */
+  private def getDaylightSavings(currentNumUnits: Long, hourInstants: List[Long]): Long = {
+    if (timeZone.observesDaylightTime()) {
+      val extraSpringForwardHours = if (hourInstants.contains(2)) {
+        val allBut2am = hourInstants.filter(_ != 2) // when springing forward, 2am is skipped for a day
+        if (allBut2am.isEmpty) {
+          23 // if we only trigger at 2am and 2am is skipped, we won't trigger for another 23 hours
+        } else {
+          // calculate the unique wrap interval when we spring forward
+          // (number of hours remaining in the day, plus the number of hours until the first trigger in the next day)
+          (24 - allBut2am.last) + (allBut2am.head - 1) - currentNumUnits
+        }
+      } else -1
+      val extraFallbackHours = 1 // we always gain an extra hour when falling back (1am is delayed until 2am)
+      Math.max(extraFallbackHours, extraSpringForwardHours)
+    } else 0
+  }
+
+}
+
+object CronContainer {
+  def apply(str: String, cronType: UnitType, timeZone: Option[TimeZone]): CronContainer = {
+    val markedUnits = CronContainer.getMarkedUnits(str, cronType.numUnitsInContainer)
+    CronContainer(str, cronType, markedUnits, timeZone.getOrElse(TimeZone.getDefault))
+  }
+
+  def getMarkedUnits(str: String, unitsInContainer: Long): List[Long] = {
+    val slash = """(\d{1,2}|\*)/(\d{1,2})""".r
+    val dash = """(\d{1,2})-(\d{1,2})""".r
+    str match {
+      case "*" => (for (i <- 0L until unitsInContainer) yield i).toList
+      case slash(start, interval) => {
+        val startInt = if (start == "*") 0 else start.toLong
+        getMarkedUnitsForSlash(startInt, interval.toLong, unitsInContainer, List(startInt))
+      }
+      case dash(first, second) =>
+        val smallest = Math.min(first.toLong, second.toLong)
+        val largest = Math.max(first.toLong, second.toLong)
+        (for (i <- smallest to largest) yield i).toList
+      case _ => str.split(",").map(_.toLong).toList.sorted
+    }
+  }
+
+  private def getMarkedUnitsForSlash(
+    start: Long,
+    interval: Long,
+    unitsInContainer: Long,
+    result: List[Long] = Nil,
+  ): List[Long] = {
+    if (start + interval >= unitsInContainer) result
+    else getMarkedUnitsForSlash(start + interval, interval, unitsInContainer, result :+ (start + interval))
+  }
+}

--- a/admin/test/com/lucidchart/piezo/admin/util/CronHelperTest.scala
+++ b/admin/test/com/lucidchart/piezo/admin/util/CronHelperTest.scala
@@ -1,8 +1,6 @@
 package com.lucidchart.piezo.admin.util
 
 import com.lucidchart.piezo.admin.utils.CronHelper
-import java.util.TimeZone
-import org.quartz.CronExpression
 import org.specs2.mutable.Specification
 
 class CronHelperTest extends Specification {
@@ -10,26 +8,15 @@ class CronHelperTest extends Specification {
   val SECOND: Int = 1
   val MINUTE: Int = 60 * SECOND
   val HOUR: Int = 60 * MINUTE
-  val EXTRA_HOUR: Int = HOUR // denotes the extra hour from daylight savings
   val DAY: Int = 24 * HOUR
   val WEEK: Int = 7 * DAY
   val YEAR: Int = 365 * DAY
   val LEAP_YEAR: Int = YEAR + DAY
   val IMPOSSIBLE: Long = Long.MaxValue
 
-  val UTC: Option[TimeZone] = Some(TimeZone.getTimeZone("UTC"))
-  val MDT: Option[TimeZone] = Some(TimeZone.getTimeZone("MST7MDT"))
-
-  def maxInterval(str: String, timeZone: Option[TimeZone] = UTC): Long = {
-    CronHelper.getMaxInterval(new CronExpression(str), timeZone)
-  }
+  def maxInterval(str: String): Long = CronHelper.getMaxInterval(str)
 
   "CronHelper" should {
-    "timezones should be configured properly" in {
-      MDT must beSome { timezone: TimeZone => timezone.observesDaylightTime() must beTrue }
-      UTC must beSome { timezone: TimeZone => timezone.observesDaylightTime() must beFalse }
-    }
-
     "validate basic cron expressions" in {
       maxInterval("* * * * * ?") mustEqual SECOND // every second
       maxInterval("0 * * * * ?") mustEqual MINUTE // second 0 of every minute
@@ -41,39 +28,17 @@ class CronHelperTest extends Specification {
 
     "validate more basic cron expressions" in {
       maxInterval("0/1 0-59 */1 * * ?") mustEqual SECOND // variations on 1 second
-      maxInterval("* * 0-23 * * ?", MDT) mustEqual SECOND
+      maxInterval("* * 0-23 * * ?") mustEqual SECOND
       maxInterval("22 2/6 * * * ?") mustEqual 6 * MINUTE // 22nd second of every 6th minute after minute 2
       maxInterval("*/15 * * * * ?") mustEqual 15 * SECOND
       maxInterval("30 10 */1 * * ?") mustEqual HOUR
       maxInterval("15 * * * * ?") mustEqual MINUTE
       maxInterval("3,2,1,0 45,44,16,15 6,5,4 * * ? *") mustEqual (21 * HOUR + 29 * MINUTE + 57 * SECOND)
-      maxInterval("50-0 30-40 14-12 * * ?") mustEqual (21 * HOUR + 49 * MINUTE + 10 * SECOND)
-      maxInterval("0 0 8-4 * * ?") mustEqual (DAY - 4 * HOUR)
-      maxInterval("0 0 0/6 * * ? *") mustEqual (6 * HOUR)
-    }
-
-    "validate daylight savings expressions with simple methods" in {
-      maxInterval("0 0 1 * * ?", UTC) mustEqual DAY
-      maxInterval("0 0 1 * * ?", MDT) mustEqual DAY + EXTRA_HOUR
-      maxInterval("0 0 2,0 * * ?", MDT) mustEqual (DAY - 2 * HOUR) + EXTRA_HOUR
-      maxInterval("0 0 2,3 * * ?", MDT) mustEqual (DAY - 1 * HOUR) + EXTRA_HOUR
-      maxInterval("0 0 2,5 * * ?", MDT) mustEqual (DAY - 5 * HOUR) + ((5 - 1) * HOUR)
-      maxInterval("0 0 2,5,6,7,12 * * ?", MDT) mustEqual (DAY - 12 * HOUR) + ((5 - 1) * HOUR)
-      maxInterval("0 0 2,22,23 * * ?", MDT) mustEqual (DAY - 23 * HOUR) + ((22 - 1) * HOUR)
-      maxInterval("0 0 2 * * ?", UTC) mustEqual DAY
-      maxInterval("0 0 2 * * ?", MDT) mustEqual DAY + 23 * HOUR
-    }
-
-    "validate daylight savings expressions with complex methods" in {
-      maxInterval("0 0 1 * 1-12 ?", UTC) mustEqual DAY
-      maxInterval("0 0 1 * 1-12 ?", MDT) mustEqual DAY + EXTRA_HOUR
-      maxInterval("0 0 2,0 * 1-12 ?", MDT) mustEqual (DAY - 2 * HOUR) + EXTRA_HOUR
-      maxInterval("0 0 2,3 * 1-12 ?", MDT) mustEqual (DAY - 1 * HOUR) + EXTRA_HOUR
-      maxInterval("0 0 2,5 * 1-12 ?", MDT) mustEqual (DAY - 5 * HOUR) + ((5 - 1) * HOUR)
-      maxInterval("0 0 2,5,6,7,12 * 1-12 ?", MDT) mustEqual (DAY - 12 * HOUR) + ((5 - 1) * HOUR)
-      maxInterval("0 0 2,22,23 * 1-12 ?", MDT) mustEqual (DAY - 23 * HOUR) + ((22 - 1) * HOUR)
-      maxInterval("0 0 2 * 1-12 ?", UTC) mustEqual DAY
-      maxInterval("0 0 2 * 1-12 ?", MDT) mustEqual DAY + 23 * HOUR
+      maxInterval("50-0 30-40 14-12 * * ?") mustEqual (1 * HOUR + 49 * MINUTE + 1 * SECOND)
+      maxInterval("0 0 8-4 * * ?") mustEqual 4 * HOUR
+      maxInterval("0 0 0/6 * * ? *") mustEqual 6 * HOUR
+      maxInterval("0 10,20,30 * * ? *") mustEqual 40 * MINUTE
+      maxInterval("0-10/2 0-5,20-25 0,5-11/2,20-23 * ? *") mustEqual 8 * HOUR + 34 * MINUTE + 50 * SECOND
     }
 
     "validate complex cron expressions" in {
@@ -83,13 +48,13 @@ class CronHelperTest extends Specification {
       maxInterval("0 0 0 29 2 ? *") mustEqual 8 * YEAR + DAY // 8 years since we skip leap day roughly every 100 years
       maxInterval("* * * 29 2 ? *") mustEqual 8 * YEAR + SECOND // every second on leap day
       maxInterval("0 11 11 11 11 ?") mustEqual LEAP_YEAR // every november 11th at 11:11am
-      maxInterval("1 2 3 ? * 6", MDT) mustEqual WEEK + EXTRA_HOUR // every saturday
-      maxInterval("0 15 10 ? * 6#3", MDT) mustEqual 5 * WEEK + EXTRA_HOUR // third saturday of every month
-      maxInterval("0 15 10 ? * MON-FRI", MDT) mustEqual 3 * DAY + EXTRA_HOUR // every weekday
-      maxInterval("0 0 0/6 * 1,2,3,4,5,6,7,8,9,10,11,12 ? *", MDT) mustEqual DAY - (18 * HOUR) + EXTRA_HOUR
-      maxInterval("* * * 1-31 * ?", MDT) mustEqual SECOND + EXTRA_HOUR
-      maxInterval("* * * * 1-12 ?", MDT) mustEqual SECOND + EXTRA_HOUR
-      maxInterval("* * * ? * 1-7", MDT) mustEqual SECOND + EXTRA_HOUR
+      maxInterval("1 2 3 ? * 6") mustEqual WEEK // every saturday
+      maxInterval("0 15 10 ? * 6#3") mustEqual 5 * WEEK // third saturday of every month
+      maxInterval("0 15 10 ? * MON-FRI") mustEqual 3 * DAY // every weekday
+      maxInterval("0 0 0/6 * 1,2,3,4,5,6,7,8,9,10,11,12 ? *") mustEqual DAY - (18 * HOUR)
+      maxInterval("* * * 1-31 * ?") mustEqual SECOND
+      maxInterval("* * * * 1-12 ?") mustEqual SECOND
+      maxInterval("* * * ? * 1-7") mustEqual SECOND
     }
   }
 }

--- a/admin/test/com/lucidchart/piezo/admin/util/CronHelperTest.scala
+++ b/admin/test/com/lucidchart/piezo/admin/util/CronHelperTest.scala
@@ -1,0 +1,95 @@
+package com.lucidchart.piezo.admin.util
+
+import com.lucidchart.piezo.admin.utils.CronHelper
+import java.util.TimeZone
+import org.quartz.CronExpression
+import org.specs2.mutable.Specification
+
+class CronHelperTest extends Specification {
+
+  val SECOND: Int = 1
+  val MINUTE: Int = 60 * SECOND
+  val HOUR: Int = 60 * MINUTE
+  val EXTRA_HOUR: Int = HOUR // denotes the extra hour from daylight savings
+  val DAY: Int = 24 * HOUR
+  val WEEK: Int = 7 * DAY
+  val YEAR: Int = 365 * DAY
+  val LEAP_YEAR: Int = YEAR + DAY
+  val IMPOSSIBLE: Long = Long.MaxValue
+
+  val UTC: Option[TimeZone] = Some(TimeZone.getTimeZone("UTC"))
+  val MDT: Option[TimeZone] = Some(TimeZone.getTimeZone("MST7MDT"))
+
+  def maxInterval(str: String, timeZone: Option[TimeZone] = UTC): Long = {
+    CronHelper.getMaxInterval(new CronExpression(str), timeZone)
+  }
+
+  "CronHelper" should {
+    "timezones should be configured properly" in {
+      MDT must beSome { timezone: TimeZone => timezone.observesDaylightTime() must beTrue }
+      UTC must beSome { timezone: TimeZone => timezone.observesDaylightTime() must beFalse }
+    }
+
+    "validate basic cron expressions" in {
+      maxInterval("* * * * * ?") mustEqual SECOND // every second
+      maxInterval("0 * * * * ?") mustEqual MINUTE // second 0 of every minute
+      maxInterval("0 0 * * * ?") mustEqual HOUR // second 0 during minute 0 of every hour
+      maxInterval("0 0 0 * * ?") mustEqual DAY // second 0 during minute 0 during hour 0 of every day
+      maxInterval("* 0 * * * ?") mustEqual (HOUR - MINUTE + SECOND) // every second during minute 0
+      maxInterval("* * 0 * * ?") mustEqual (DAY - HOUR + SECOND)
+    }
+
+    "validate more basic cron expressions" in {
+      maxInterval("0/1 0-59 */1 * * ?") mustEqual SECOND // variations on 1 second
+      maxInterval("* * 0-23 * * ?", MDT) mustEqual SECOND
+      maxInterval("22 2/6 * * * ?") mustEqual 6 * MINUTE // 22nd second of every 6th minute after minute 2
+      maxInterval("*/15 * * * * ?") mustEqual 15 * SECOND
+      maxInterval("30 10 */1 * * ?") mustEqual HOUR
+      maxInterval("15 * * * * ?") mustEqual MINUTE
+      maxInterval("3,2,1,0 45,44,16,15 6,5,4 * * ? *") mustEqual (21 * HOUR + 29 * MINUTE + 57 * SECOND)
+      maxInterval("50-0 30-40 14-12 * * ?") mustEqual (21 * HOUR + 49 * MINUTE + 10 * SECOND)
+      maxInterval("0 0 8-4 * * ?") mustEqual (DAY - 4 * HOUR)
+      maxInterval("0 0 0/6 * * ? *") mustEqual (6 * HOUR)
+    }
+
+    "validate daylight savings expressions with simple methods" in {
+      maxInterval("0 0 1 * * ?", UTC) mustEqual DAY
+      maxInterval("0 0 1 * * ?", MDT) mustEqual DAY + EXTRA_HOUR
+      maxInterval("0 0 2,0 * * ?", MDT) mustEqual (DAY - 2 * HOUR) + EXTRA_HOUR
+      maxInterval("0 0 2,3 * * ?", MDT) mustEqual (DAY - 1 * HOUR) + EXTRA_HOUR
+      maxInterval("0 0 2,5 * * ?", MDT) mustEqual (DAY - 5 * HOUR) + ((5 - 1) * HOUR)
+      maxInterval("0 0 2,5,6,7,12 * * ?", MDT) mustEqual (DAY - 12 * HOUR) + ((5 - 1) * HOUR)
+      maxInterval("0 0 2,22,23 * * ?", MDT) mustEqual (DAY - 23 * HOUR) + ((22 - 1) * HOUR)
+      maxInterval("0 0 2 * * ?", UTC) mustEqual DAY
+      maxInterval("0 0 2 * * ?", MDT) mustEqual DAY + 23 * HOUR
+    }
+
+    "validate daylight savings expressions with complex methods" in {
+      maxInterval("0 0 1 * 1-12 ?", UTC) mustEqual DAY
+      maxInterval("0 0 1 * 1-12 ?", MDT) mustEqual DAY + EXTRA_HOUR
+      maxInterval("0 0 2,0 * 1-12 ?", MDT) mustEqual (DAY - 2 * HOUR) + EXTRA_HOUR
+      maxInterval("0 0 2,3 * 1-12 ?", MDT) mustEqual (DAY - 1 * HOUR) + EXTRA_HOUR
+      maxInterval("0 0 2,5 * 1-12 ?", MDT) mustEqual (DAY - 5 * HOUR) + ((5 - 1) * HOUR)
+      maxInterval("0 0 2,5,6,7,12 * 1-12 ?", MDT) mustEqual (DAY - 12 * HOUR) + ((5 - 1) * HOUR)
+      maxInterval("0 0 2,22,23 * 1-12 ?", MDT) mustEqual (DAY - 23 * HOUR) + ((22 - 1) * HOUR)
+      maxInterval("0 0 2 * 1-12 ?", UTC) mustEqual DAY
+      maxInterval("0 0 2 * 1-12 ?", MDT) mustEqual DAY + 23 * HOUR
+    }
+
+    "validate complex cron expressions" in {
+      maxInterval("0/15 * * 1-12 * ?") mustEqual 19 * DAY + 15 * SECOND // every 15 seconds on days 1-12 of the month
+      maxInterval("* * * * 1-11 ?") mustEqual 31 * DAY + SECOND // every second of every month except for december
+      maxInterval("* * * * * ? 1998") mustEqual IMPOSSIBLE // every second of 1998
+      maxInterval("0 0 0 29 2 ? *") mustEqual 8 * YEAR + DAY // 8 years since we skip leap day roughly every 100 years
+      maxInterval("* * * 29 2 ? *") mustEqual 8 * YEAR + SECOND // every second on leap day
+      maxInterval("0 11 11 11 11 ?") mustEqual LEAP_YEAR // every november 11th at 11:11am
+      maxInterval("1 2 3 ? * 6", MDT) mustEqual WEEK + EXTRA_HOUR // every saturday
+      maxInterval("0 15 10 ? * 6#3", MDT) mustEqual 5 * WEEK + EXTRA_HOUR // third saturday of every month
+      maxInterval("0 15 10 ? * MON-FRI", MDT) mustEqual 3 * DAY + EXTRA_HOUR // every weekday
+      maxInterval("0 0 0/6 * 1,2,3,4,5,6,7,8,9,10,11,12 ? *", MDT) mustEqual DAY - (18 * HOUR) + EXTRA_HOUR
+      maxInterval("* * * 1-31 * ?", MDT) mustEqual SECOND + EXTRA_HOUR
+      maxInterval("* * * * 1-12 ?", MDT) mustEqual SECOND + EXTRA_HOUR
+      maxInterval("* * * ? * 1-7", MDT) mustEqual SECOND + EXTRA_HOUR
+    }
+  }
+}


### PR DESCRIPTION
See this PROD issue: https://lucidatlassian.atlassian.net/browse/PROD-2269

It should now be impossible to change a job trigger schedule such that the maximum schedule period is larger than the monitoring window. Additionally, it should be impossible to change the monitoring window such that it’s shorter than the maximum schedule period. 