### PR TITLE
Dont use SchedulerFactory reserved prefixes

### DIFF
--- a/worker/src/main/scala/com/lucidchart/piezo/ConnectionProvider.scala
+++ b/worker/src/main/scala/com/lucidchart/piezo/ConnectionProvider.scala
@@ -21,7 +21,7 @@ class ConnectionProvider(props: Properties) {
   val logger = LoggerFactory.getLogger(this.getClass)
   private val dataSource = props.getProperty("org.quartz.jobStore.dataSource")
   private val jdbcURL = if (dataSource != null) props.getProperty("org.quartz.dataSource." + dataSource + ".URL") else null
-  private val detectIpAddressFailover = if (dataSource != null) props.getProperty("org.quartz.dataSource." + dataSource + ".ipFailover") == "true" else false
+  private val detectIpAddressFailover = props.getProperty("supportIPFailover") == "true"
   // Removes "jdbc:mysql://" prefix and ":{port}..." suffix
   private val dataSourceHostname = if (jdbcURL != null) jdbcURL.replace("jdbc:mysql://", "").split(":")(0) else null
 
@@ -37,7 +37,7 @@ class ConnectionProvider(props: Properties) {
   private val pool: Pool = new Pool(getIP)
 
   // Intended to be used only for tests. This mocks an IP failover every time a connection is retreived
-  private val causeFailoverEveryConnection = if (dataSource != null) props.getProperty("org.quartz.dataSource." + dataSource + ".causeFailoverEveryConnection") == "true" else false
+  private val causeFailoverEveryConnection = props.getProperty("causeFailoverEveryConnection") == "true"
 
   def createNewConnectionProvider(): Option[HikariCpPoolingConnectionProvider] = {
     if(dataSource != null) {

--- a/worker/src/test/resources/quartz_test_mysql.properties
+++ b/worker/src/test/resources/quartz_test_mysql.properties
@@ -31,4 +31,4 @@ org.quartz.dataSource.test_jobs.user: root
 org.quartz.dataSource.test_jobs.password: root
 org.quartz.dataSource.test_jobs.maxConnections: 10
 org.quartz.dataSource.test_jobs.validationQuery: select 0
-org.quartz.dataSource.test_jobs.ipFailover: true
+supportIPFailover: true

--- a/worker/src/test/resources/quartz_test_mysql_failover_every_connection.properties
+++ b/worker/src/test/resources/quartz_test_mysql_failover_every_connection.properties
@@ -31,7 +31,7 @@ org.quartz.dataSource.test_jobs.user: root
 org.quartz.dataSource.test_jobs.password: root
 org.quartz.dataSource.test_jobs.maxConnections: 10
 org.quartz.dataSource.test_jobs.validationQuery: select 0
-org.quartz.dataSource.test_jobs.ipFailover: true
+supportIPFailover: true
 
 # Unique configuration to this file
-org.quartz.dataSource.test_jobs.causeFailoverEveryConnection: true
+causeFailoverEveryConnection: true

--- a/worker/src/test/scala/com/lucidchart/piezo/ModelTest.scala
+++ b/worker/src/test/scala/com/lucidchart/piezo/ModelTest.scala
@@ -69,7 +69,7 @@ class ModelTest extends Specification with BeforeAll with AfterAll {
 
     "JobHistoryModel" should {
         "work correctly" in {
-          properties.getProperty("org.quartz.dataSource.test_jobs.causeFailoverEveryConnection") must beNull
+          properties.getProperty("causeFailoverEveryConnection") must beNull
           val jobHistoryModel = new JobHistoryModel(properties)
           val jobKey = new JobKey("blah", "blah")
           val triggerKey = new TriggerKey("blahtn", "blahtg")
@@ -81,7 +81,7 @@ class ModelTest extends Specification with BeforeAll with AfterAll {
         }
 
         "work correctly with a failover for every connection to the database" in {
-          propertiesWithFailoverEveryConnection.getProperty("org.quartz.dataSource.test_jobs.causeFailoverEveryConnection") mustEqual("true")
+          propertiesWithFailoverEveryConnection.getProperty("causeFailoverEveryConnection") mustEqual("true")
           val jobHistoryModel = new JobHistoryModel(propertiesWithFailoverEveryConnection)
           val jobKey = new JobKey("blahc", "blahc")
           val triggerKey = new TriggerKey("blahtnc", "blahtgc")


### PR DESCRIPTION
When using the newest version of `piezo-admin` with the `StdSchedulerFactory` [provided](https://github.com/quartz-scheduler/quartz/blob/9035cb472a15f34b378e8e0c41aa428350b0188b/quartz/src/main/java/org/quartz/impl/StdSchedulerFactory.java#L214) by quartz, the following exceptions are thrown:

```
Exception in thread "main" org.quartz.SchedulerException: Could not initialize DataSource: {dataSourceName} [See nested exception: java.lang.NoSuchMethodException: No setter for property 'ipFailover']
    at org.quartz.impl.StdSchedulerFactory.instantiate(StdSchedulerFactory.java:1054)
    at org.quartz.impl.StdSchedulerFactory.getScheduler(StdSchedulerFactory.java:1579)
    ...
Caused by: java.lang.NoSuchMethodException: No setter for property 'ipFailover'
    at org.quartz.impl.StdSchedulerFactory.setBeanProps(StdSchedulerFactory.java:1467)
    at org.quartz.impl.StdSchedulerFactory.populateProviderWithExtraProps(StdSchedulerFactory.java:1425)
    at org.quartz.impl.StdSchedulerFactory.instantiate(StdSchedulerFactory.java:1052)
```

It seems that the `StdSchedulerFactory` in quartz is very protective of the configuration properties provided for `org.quartz.jobStore.dataSource={dataSourceName}`. The properties set on `org.quartz.dataSource.{dataSourceName}` must follow the provided pattern and `org.quartz.dataSource.{dataSourceName}.ipFailover` is not in that list by default:

```
org.quartz.dataSource.{dataSourceName}.driver
org.quartz.dataSource.{dataSourceName}.URL
org.quartz.dataSource.{dataSourceName}.user
org.quartz.dataSource.{dataSourceName}.password
org.quartz.dataSource.{dataSourceName}.maxConnections
org.quartz.dataSource.{dataSourceName}.validationQuery
org.quartz.dataSource.{dataSourceName}.poolingProvider
```

I think the best option is to use a different prefix for ipFailover that isn't already [reserved](https://github.com/quartz-scheduler/quartz/blob/9035cb472a15f34b378e8e0c41aa428350b0188b/quartz/src/main/java/org/quartz/impl/StdSchedulerFactory.java#L214) by StdSchedulerFactory.scala