### PR TITLE
Add ability to enumerate monitoring team options in config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ src_managed/
 project/boot/
 project/plugins/project/
 project/project/
+project/metals.sbt
 
 # Scala-IDE specific
 .scala_dependencies
@@ -17,5 +18,5 @@ project/project/
 .idea_modules
 .bsp
 .metals
-.bloop/
-project/metals.sbt
+.bloop
+.vscode

--- a/admin/app/Application.scala
+++ b/admin/app/Application.scala
@@ -27,6 +27,7 @@ class PiezoAdminComponents(context: Context) extends BuiltInComponentsFromContex
 
   lazy val schedulerFactory: WorkerSchedulerFactory = new WorkerSchedulerFactory()
   lazy val jobFormHelper: JobFormHelper = wire[JobFormHelper]
+  lazy val monitoringTeams: MonitoringTeams = MonitoringTeams(configuration)
 
   lazy val triggers: Triggers = wire[Triggers]
   lazy val jobs: Jobs = wire[Jobs]

--- a/admin/app/com/lucidchart/piezo/admin/models/MonitoringTeams.scala
+++ b/admin/app/com/lucidchart/piezo/admin/models/MonitoringTeams.scala
@@ -1,0 +1,39 @@
+package com.lucidchart.piezo.admin.models
+
+import play.api.Configuration
+import java.nio.file.Files
+import play.api.libs.json.Json
+import scala.util.Try
+import java.io.File
+import java.io.FileInputStream
+import play.api.libs.json.JsArray
+import play.api.Logging
+import scala.util.control.NonFatal
+import scala.util.Failure
+
+case class MonitoringTeams(value: Seq[String]) {
+  def teamsDefined: Boolean = value.nonEmpty
+}
+object MonitoringTeams extends Logging {
+  def apply(configuration: Configuration): MonitoringTeams = {
+    val path = configuration.getOptional[String]("com.lucidchart.piezo.admin.monitoringTeams.path")
+
+    val value = path.flatMap { p =>
+      Try {
+        Json.parse(new FileInputStream(p))
+          .as[JsArray]
+          .value
+          .map(entry => (entry \ "name").as[String])
+          .toSeq
+      }.recoverWith {
+        case NonFatal(e) =>
+          logger.error(s"Error reading monitoring teams from $p", e)
+          Failure(e)
+      }.toOption
+    }.getOrElse(Seq.empty)
+
+    MonitoringTeams(value)
+  }
+
+  def empty: MonitoringTeams = MonitoringTeams(Seq.empty)
+}

--- a/admin/app/com/lucidchart/piezo/admin/views/editTrigger.scala.html
+++ b/admin/app/com/lucidchart/piezo/admin/views/editTrigger.scala.html
@@ -1,15 +1,16 @@
 @(
 triggersByGroup: scala.collection.mutable.Buffer[(String, scala.collection.immutable.List[org.quartz.TriggerKey])],
-triggerForm: Form[(org.quartz.Trigger, com.lucidchart.piezo.TriggerMonitoringPriority.Value, Int, Option[String])],
+monitoringTeams: Seq[String],
+triggerForm: Form[com.lucidchart.piezo.admin.controllers.TriggerFormValue],
 formAction: play.api.mvc.Call,
 existing: Boolean,
 isTemplate: Boolean,
 errorMessage: Option[String] = None,
-scripts: List[String] = List[String]("js/jobData.js", "js/typeAhead.js")
+scripts: List[String] = List[String]("js/jobData.js", "js/typeAhead.js", "js/triggerMonitoring.js")
 )(
 implicit
 request: play.api.mvc.Request[AnyContent],
-messagesProvider: play.api.i18n.MessagesProvider
+messagesProvider: play.api.i18n.MessagesProvider,
 )
 
 @import com.lucidchart.piezo.TriggerMonitoringPriority
@@ -67,12 +68,18 @@ messagesProvider: play.api.i18n.MessagesProvider
     }
     }
     @helper.select(triggerForm("triggerMonitoringPriority"), TriggerMonitoringPriority.values.map(tp => tp.name -> tp.name), Symbol("_label") -> "Monitoring Priority", Symbol("labelClass") -> "col-sm-2 text-right", Symbol("inputDivClass") -> "col-sm-4", Symbol("class") -> "form-control", Symbol("value") -> triggerForm.data.get("triggerMonitoringPriority").getOrElse(TriggerMonitoringPriority.Low), Symbol("placeholder") -> TriggerMonitoringPriority.Low)
-    @helper.input(triggerForm("triggerMaxErrorTime"), Symbol("_label") -> "Monitoring - Max Seconds Between Successes", Symbol("labelClass") -> "col-sm-2 text-right", Symbol("inputDivClass") -> "col-sm-4", Symbol("placeholder") -> "", Symbol("value") -> triggerForm.data.get("triggerMaxErrorTime").getOrElse(300)) { (id, name, value, args) =>
-      <input type="number" class="form-control form-inline-control " name="@name" id="@id" @toHtmlArgs(args)>
-    }
-    @helper.input(triggerForm("triggerMonitoringTeam"), Symbol("_label") -> "Monitoring team", Symbol("labelClass") -> "col-sm-2 text-right", Symbol("inputDivClass") -> "col-sm-4", Symbol("placeholder") -> "", Symbol("value") -> triggerForm.data.get("triggerMonitoringTeam").getOrElse(None)) { (id, name, value, args) =>
-      <input type="text" class="form-control form-inline-control" name="@name" id="@id" @toHtmlArgs(args)>
-    }
+    <div id="triggerMonitoringDetails">
+        @helper.input(triggerForm("triggerMaxErrorTime"), Symbol("_label") -> "Monitoring - Max Seconds Between Successes", Symbol("labelClass") -> "col-sm-2 text-right", Symbol("inputDivClass") -> "col-sm-4", Symbol("placeholder") -> "", Symbol("value") -> triggerForm.data.get("triggerMaxErrorTime").getOrElse(300)) { (id, name, value, args) =>
+        <input type="number" class="form-control form-inline-control " name="@name" id="@id" @toHtmlArgs(args)>
+        }
+        @if(monitoringTeams.nonEmpty) {
+            @helper.select(triggerForm("triggerMonitoringTeam"), monitoringTeams.map(mt => mt -> mt), Symbol("_default") -> "Select team", Symbol("_label") -> "Monitoring team", Symbol("labelClass") -> "col-sm-2 text-right", Symbol("inputDivClass") -> "col-sm-4", Symbol("class") -> "form-control", Symbol("value") -> triggerForm.data.get("triggerMonitoringTeam").getOrElse(""))
+        } else {
+            @helper.input(triggerForm("triggerMonitoringTeam"), Symbol("_label") -> "Monitoring team", Symbol("labelClass") -> "col-sm-2 text-right", Symbol("inputDivClass") -> "col-sm-4", Symbol("placeholder") -> "", Symbol("value") -> triggerForm.data.get("triggerMonitoringTeam").getOrElse(None)) { (id, name, value, args) =>
+                <input type="text" class="form-control form-inline-control" name="@name" id="@id" @toHtmlArgs(args)>
+            }
+        }
+    </div>
 
     @helper.input(triggerForm("description"), Symbol("_label") -> "Description", Symbol("labelClass") -> "col-sm-2 text-right", Symbol("inputDivClass") -> "col-sm-10", Symbol("placeholder") -> "Description", Symbol("value")-> triggerForm.data.get("description").getOrElse("")) { (id, name, value, args) =>
       <input type="text" class="form-control form-inline-control " name="@name" id="@id" @toHtmlArgs(args)>

--- a/admin/conf/application.conf
+++ b/admin/conf/application.conf
@@ -46,3 +46,14 @@ com.lucidchart.piezo.heartbeatFile="/tmp/piezo/workerHeartbeatFile"
 com.lucidchart.piezo.admin.production=false
 healthCheck.worker.minutesBetween=5
 play.application.loader=com.lucidchart.piezo.admin.PiezoAdminApplicationLoader
+
+# Monitoring teams
+# ~~~~~
+# Path to a JSON file that fills the "Monitoring Team" dropdown on editTrigger
+# in the admin UI with a predefined set of team names. File format:
+# [
+#  {"name": "team1"},
+#  {"name": "team2"}
+# ]
+# If this is left blank, monitoring team will be a freeform input.
+# com.lucidchart.piezo.admin.monitoringTeams.path = "/etc/piezo/teams.json"

--- a/admin/public/js/triggerMonitoring.js
+++ b/admin/public/js/triggerMonitoring.js
@@ -1,0 +1,15 @@
+window.addEventListener('load', () => {
+    const priorityInput = document.getElementById('triggerMonitoringPriority');
+    const setMonitoringFieldVisibility = () => {
+        const priority = priorityInput.value;
+        const monitoringDetails = document.getElementById('triggerMonitoringDetails');
+        if (priority == 'Off') {
+            monitoringDetails.style.display = 'none'; // hide
+        } else {
+            monitoringDetails.style.display = 'block'; // show
+        }
+    };
+
+    priorityInput.addEventListener('change', setMonitoringFieldVisibility);
+    setMonitoringFieldVisibility();
+}, {once: true});

--- a/admin/test/com/lucidchart/piezo/admin/controllers/JobsService.scala
+++ b/admin/test/com/lucidchart/piezo/admin/controllers/JobsService.scala
@@ -1,7 +1,6 @@
 package com.lucidchart.piezo.admin.controllers
 
 import org.specs2.mutable._
-
 import play.api.test._
 import play.api.test.Helpers._
 import com.lucidchart.piezo.jobs.monitoring.HeartBeat
@@ -14,8 +13,8 @@ import com.lucidchart.piezo.util.DummyClassGenerator
 import play.api.mvc.{Result, AnyContentAsEmpty}
 import java.util.Properties
 import play.api.Configuration
-
 import scala.concurrent.Future
+import com.lucidchart.piezo.admin.models.MonitoringTeams
 
 /**
   * Add your spec here.
@@ -39,7 +38,7 @@ class JobsService extends Specification {
        properties.load(propertiesStream)
        schedulerFactory.initialize(properties)
 
-       val jobsController = new Jobs(schedulerFactory, jobView, Helpers.stubControllerComponents())
+       val jobsController = new Jobs(schedulerFactory, jobView, Helpers.stubControllerComponents(), MonitoringTeams.empty)
        val request: FakeRequest[AnyContentAsEmpty.type] = FakeRequest(GET, "/jobs/missinggroup/missingname")
        val missingJob: Future[Result] = jobsController.getJob("missinggroup", "missingname")(request)
 
@@ -57,8 +56,7 @@ class JobsService extends Specification {
        val scheduler = schedulerFactory.getScheduler()
        createJob(scheduler)
 
-
-       val jobsController = new Jobs(schedulerFactory, jobView, Helpers.stubControllerComponents())
+       val jobsController = new Jobs(schedulerFactory, jobView, Helpers.stubControllerComponents(), MonitoringTeams.empty)
        val request: FakeRequest[AnyContentAsEmpty.type] = FakeRequest(GET, "/jobs/" + jobGroup + "/" + jobName)
        val validJob: Future[Result] = jobsController.getJob(jobGroup, jobName)(request)
 

--- a/admin/test/com/lucidchart/piezo/admin/controllers/TriggersService.scala
+++ b/admin/test/com/lucidchart/piezo/admin/controllers/TriggersService.scala
@@ -1,7 +1,6 @@
 package com.lucidchart.piezo.admin.controllers
 
 import org.specs2.mutable._
-
 import play.api.test._
 import play.api.test.Helpers._
 import com.lucidchart.piezo.WorkerSchedulerFactory
@@ -9,49 +8,49 @@ import TestUtil._
 import java.util.Properties
 import play.api.mvc.{AnyContentAsEmpty, Result}
 import scala.concurrent.Future
+import com.lucidchart.piezo.admin.models.MonitoringTeams
 
 /**
-  * Add your spec here.
-  * You can mock out a whole application including requests, plugins etc.
-  * For more information, consult the wiki.
-  */
+ * Add your spec here. You can mock out a whole application including requests, plugins etc. For more information,
+ * consult the wiki.
+ */
 class TriggersService extends Specification {
-   "Triggers" should {
+  "Triggers" should {
 
-     "send 404 on a non-existent trigger request" in {
-       val schedulerFactory: WorkerSchedulerFactory = new WorkerSchedulerFactory()
+    "send 404 on a non-existent trigger request" in {
+      val schedulerFactory: WorkerSchedulerFactory = new WorkerSchedulerFactory()
 
-       val propertiesStream = getClass().getResourceAsStream("/quartz_test.properties")
-       val properties = new Properties
-       properties.load(propertiesStream)
-       schedulerFactory.initialize(properties)
+      val propertiesStream = getClass().getResourceAsStream("/quartz_test.properties")
+      val properties = new Properties
+      properties.load(propertiesStream)
+      schedulerFactory.initialize(properties)
 
-       val triggersController = new Triggers(schedulerFactory, Helpers.stubControllerComponents())
-       val request: FakeRequest[AnyContentAsEmpty.type] = FakeRequest(GET, "/triggers/missinggroup/missingname")
-       val missingTrigger: Future[Result] = triggersController.getTrigger("missinggroup", "missingname")(request)
+      val triggersController = new Triggers(schedulerFactory, Helpers.stubControllerComponents(), MonitoringTeams.empty)
+      val request: FakeRequest[AnyContentAsEmpty.type] = FakeRequest(GET, "/triggers/missinggroup/missingname")
+      val missingTrigger: Future[Result] = triggersController.getTrigger("missinggroup", "missingname")(request)
 
-       status(missingTrigger) must equalTo(NOT_FOUND)
-       contentType(missingTrigger) must beSome.which(_ == "text/html")
-       contentAsString(missingTrigger) must contain ("Trigger missinggroup missingname not found")
-     }
+      status(missingTrigger) must equalTo(NOT_FOUND)
+      contentType(missingTrigger) must beSome.which(_ == "text/html")
+      contentAsString(missingTrigger) must contain("Trigger missinggroup missingname not found")
+    }
 
-     "send valid trigger details" in {
-       val schedulerFactory: WorkerSchedulerFactory = new WorkerSchedulerFactory()
-       val propertiesStream = getClass().getResourceAsStream("/quartz_test.properties")
-       val properties = new Properties
-       properties.load(propertiesStream)
-       schedulerFactory.initialize(properties)
-       val scheduler = schedulerFactory.getScheduler()
-       createJob(scheduler)
+    "send valid trigger details" in {
+      val schedulerFactory: WorkerSchedulerFactory = new WorkerSchedulerFactory()
+      val propertiesStream = getClass().getResourceAsStream("/quartz_test.properties")
+      val properties = new Properties
+      properties.load(propertiesStream)
+      schedulerFactory.initialize(properties)
+      val scheduler = schedulerFactory.getScheduler()
+      createJob(scheduler)
 
-       val triggersController = new Triggers(schedulerFactory, Helpers.stubControllerComponents())
-       val request: FakeRequest[AnyContentAsEmpty.type] = FakeRequest(GET, "/triggers/" + jobGroup + "/" + jobName)
-       val validTrigger: Future[Result] = triggersController.getTrigger(triggerGroup, triggerName)(request)
+      val triggersController = new Triggers(schedulerFactory, Helpers.stubControllerComponents(), MonitoringTeams.empty)
+      val request: FakeRequest[AnyContentAsEmpty.type] = FakeRequest(GET, "/triggers/" + jobGroup + "/" + jobName)
+      val validTrigger: Future[Result] = triggersController.getTrigger(triggerGroup, triggerName)(request)
 
-       status(validTrigger) must equalTo(OK)
-       contentType(validTrigger) must beSome.which(_ == "text/html")
-       contentAsString(validTrigger) must contain (triggerGroup)
-       contentAsString(validTrigger) must contain (triggerName)
-     }
-   }
- }
+      status(validTrigger) must equalTo(OK)
+      contentType(validTrigger) must beSome.which(_ == "text/html")
+      contentAsString(validTrigger) must contain(triggerGroup)
+      contentAsString(validTrigger) must contain(triggerName)
+    }
+  }
+}


### PR DESCRIPTION
Optionally adds the ability to provide a list of teams in config. If provided, the freeform "Monitoring team" field on a trigger will change to a required dropdown. Monitoring fields will also be hidden when monitoring priority is Off.

This will allow us to enforce team ownership of job triggers (if monitoring is on).

A future change will set the list of teams on each jobs host in chef. Piezo's behavior is unchanged if there are no teams set in config, so this is fully backwards compatible.

If the team field has a value that is not in the list of valid teams once it's added, a valid team must be selected the next time the trigger is edited.